### PR TITLE
Make auto browser opening optional

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -23,7 +23,7 @@ from .route_handlers import handle_profile_api
 from .utils import prepare_tmp_dir
 
 
-def start_server(port):
+def start_server(port, open_browser):
   """Starts Flask web server."""
 
   # Define and prepare directories.
@@ -63,8 +63,9 @@ def start_server(port):
   host = '0.0.0.0'
   url = 'http://localhost:{}'.format(port)
 
-  # Open new browser window after short delay.
-  threading.Timer(1, lambda: webbrowser.open(url)).start()
+  if open_browser:
+    # Open new browser window after short delay.
+    threading.Timer(1, lambda: webbrowser.open(url)).start()
 
   # Starting the server, and then opening browser after a delay
   app.run(host, port, threaded=True)

--- a/ui.py
+++ b/ui.py
@@ -27,6 +27,7 @@ from tensorflow.python.pywrap_tensorflow import ProfilerFromFile
 FLAGS = flags.FLAGS
 flags.DEFINE_integer('server_port', 7007, 'Flask server port.')
 flags.DEFINE_string('profile_context_path', '', 'Path to profile context.')
+flags.DEFINE_boolean('browser', True, 'Open browser after startup.')
 
 
 def main(_):
@@ -46,7 +47,7 @@ def main(_):
   ProfilerFromFile(profile_path.encode('utf-8'))
 
   # Start server.
-  start_server(FLAGS.server_port)
+  start_server(FLAGS.server_port, FLAGS.browser)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make browser opening optional with `--browser=False` (much like Jupyter's `--no-browser` option). Makes it easier when you are not running this locally / the server is only reachable by port forwarding through a bastion.